### PR TITLE
fragment 編集の draft 機能

### DIFF
--- a/.idea/biome.xml
+++ b/.idea/biome.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="BiomeSettings">
     <option name="applySafeFixesOnSave" value="true" />
+    <option name="applyUnsafeFixesOnSave" value="true" />
     <option name="formatOnSave" value="true" />
   </component>
 </project>

--- a/src/client/component/EditFragmentForm.tsx
+++ b/src/client/component/EditFragmentForm.tsx
@@ -1,39 +1,60 @@
 import FragmentEditor from '@/client/component/FragmentEditor'
 import type { FragmentFormValues } from '@/client/component/FragmentForm'
+import useEditFragmentDraft from '@/client/hook/useEditFragmentDraft'
+import type { Fragment } from '@/client/model/fragment'
 import { Button, Group } from '@mantine/core'
 import { useForm } from '@mantine/form'
 import { getHotkeyHandler } from '@mantine/hooks'
 
 export type EditFragmentFormProps = {
-  currentContent: string
   closeEditor: () => void
   updateFragment: (content: string) => Promise<void>
+  fragment: Fragment
 }
 
 export default function EditFragmentForm(props: EditFragmentFormProps) {
+  const { getDraft, saveDraft, removeDraft } = useEditFragmentDraft(
+    props.fragment.id,
+  )
+
   // TODO: FragmentForm と重複してるので、どうにかしたい
   const form = useForm<FragmentFormValues>({
     initialValues: {
-      content: props.currentContent,
+      /**
+       * 空の draft は復元する意味がないので、元の content を表示
+       * ただし、実際は親コンポーネントの都合で editor は表示されない
+       */
+      content: getDraft() || props.fragment.content,
     },
     validate: {
       content: (content) =>
         content.length > 0 ? null : '1文字以上入力してください',
     },
+    onValuesChange: ({ content }) => {
+      saveDraft(content)
+    },
   })
 
   const handleSubmit = form.onSubmit(async (values) => {
+    // fragment の更新後に editor を閉じるので、form の reset はしない
     await props.updateFragment(values.content)
+    removeDraft()
     props.closeEditor()
   })
   const onKeyDown = getHotkeyHandler([['mod+Enter', handleSubmit]])
+
+  // TODO: ダイアログを出す
+  const handleCancel = () => {
+    removeDraft()
+    props.closeEditor()
+  }
 
   return (
     <>
       <form onSubmit={handleSubmit}>
         <FragmentEditor form={form} onKeyDown={onKeyDown} />
         <Group justify='flex-end' mt='md'>
-          <Button variant='default' onClick={props.closeEditor}>
+          <Button variant='default' onClick={handleCancel}>
             キャンセル
           </Button>
           <Button type='submit'>更新</Button>

--- a/src/client/component/EditFragmentForm.tsx
+++ b/src/client/component/EditFragmentForm.tsx
@@ -19,6 +19,7 @@ export default function EditFragmentForm(props: EditFragmentFormProps) {
 
   // TODO: FragmentForm と重複してるので、どうにかしたい
   const form = useForm<FragmentFormValues>({
+    mode: 'uncontrolled',
     initialValues: {
       /**
        * 空の draft は復元する意味がないので、元の content を表示

--- a/src/client/component/FragmentForm.tsx
+++ b/src/client/component/FragmentForm.tsx
@@ -13,9 +13,6 @@ export interface FragmentFormValues {
 }
 
 const LOCAL_STORAGE_KEY_NEW_FRAGMENT = 'draft-new-fragment'
-function generateLocalStorageKeyForEditFragment(id: number) {
-  return `draft-fragment-${id}`
-}
 
 export function FragmentForm({ onSubmit }: FragmentFormProps) {
   const form = useForm<FragmentFormValues>({

--- a/src/client/component/FragmentViewer.tsx
+++ b/src/client/component/FragmentViewer.tsx
@@ -1,4 +1,5 @@
 import EditFragmentForm from '@/client/component/EditFragmentForm'
+import useEditFragmentDraft from '@/client/hook/useEditFragmentDraft'
 import type { Fragment } from '@/client/model/fragment'
 import {
   ActionIcon,
@@ -77,7 +78,9 @@ export function FragmentViewer({
   fragment,
   updateFragment,
 }: FragmentViewerProps) {
-  const [showEditor, setShowEditor] = useState(false)
+  const { getDraft } = useEditFragmentDraft(fragment.id)
+  // 空でない draft が存在したら、初めから editor を表示する
+  const [showEditor, setShowEditor] = useState(() => !!getDraft())
   const { hovered, ref } = useHover()
 
   const showToolBox = hovered && !showEditor
@@ -98,8 +101,8 @@ export function FragmentViewer({
         {showEditor ? (
           <EditFragmentForm
             closeEditor={() => setShowEditor(false)}
-            currentContent={fragment.content}
             updateFragment={updateFragment}
+            fragment={fragment}
           />
         ) : (
           <FragmentContent fragment={fragment} />

--- a/src/client/hook/useEditFragmentDraft.ts
+++ b/src/client/hook/useEditFragmentDraft.ts
@@ -1,0 +1,30 @@
+import type { FragmentId } from '@/client/model/fragment'
+import { useCallback, useMemo } from 'react'
+
+export default function useEditFragmentDraft(fragmentId: FragmentId) {
+  const localStorageKey = useMemo(
+    () => `draft-fragment-${fragmentId}`,
+    [fragmentId],
+  )
+
+  const getDraft = useCallback((): string | null => {
+    return localStorage.getItem(localStorageKey)
+  }, [localStorageKey])
+
+  const saveDraft = useCallback(
+    (content: string) => {
+      localStorage.setItem(localStorageKey, content)
+    },
+    [localStorageKey],
+  )
+
+  const removeDraft = useCallback(() => {
+    localStorage.removeItem(localStorageKey)
+  }, [localStorageKey])
+
+  return {
+    getDraft,
+    saveDraft,
+    removeDraft,
+  }
+}

--- a/src/client/model/fragment.ts
+++ b/src/client/model/fragment.ts
@@ -1,5 +1,9 @@
+import type { Brand } from '@/common/brand'
+
+export type FragmentId = Brand<number, 'FragmentId'>
+
 export interface Fragment {
-  id: number
+  id: FragmentId
   content: string
 }
 

--- a/src/common/brand.ts
+++ b/src/common/brand.ts
@@ -1,0 +1,1 @@
+export type Brand<K, T> = K & { __brand: T }


### PR DESCRIPTION
- 編集中にリロードしても、editor が開かれたままにし、編集内容を復元する
- 更新時に draft を削除する
- 編集のキャンセル時に draft を削除する

エッジケースの挙動
- 編集で内容が空になった場合、editor は閉じ、編集内容は復元**しない**