### PR TITLE
コードブロックにコピーボタンを追加

### DIFF
--- a/src/client/component/FragmentViewer.module.css
+++ b/src/client/component/FragmentViewer.module.css
@@ -3,20 +3,7 @@
     margin-bottom: 0;
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  ul,
-  p,
-  pre {
+  > * {
     margin-bottom: 1rem;
-  }
-
-  ul ul,
-  li p {
-    margin-bottom: 0;
   }
 }

--- a/src/client/component/FragmentViewer.module.css
+++ b/src/client/component/FragmentViewer.module.css
@@ -1,5 +1,5 @@
 .markdown {
-  :last-child {
+  > :last-child {
     margin-bottom: 0;
   }
 

--- a/src/client/component/markdown/RichCode.tsx
+++ b/src/client/component/markdown/RichCode.tsx
@@ -40,21 +40,22 @@ export function RichCode({ code, lang }: CodeBlockProps) {
         style={{ zIndex: 5 }}
       >
         <CopyButton value={code} timeout={1500}>
-          {({ copied, copy }) => (
-            <Tooltip label={copied ? 'コピーされました' : 'コピー'} withArrow>
-              <ActionIcon
-                color={copied ? 'teal' : 'gray'}
-                variant='subtle'
-                onClick={copy}
-              >
-                {copied ? (
-                  <IconCheck style={{ width: rem(16) }} />
-                ) : (
-                  <IconCopy style={{ width: rem(16) }} />
-                )}
+          {({ copied, copy }) => {
+            if (copied) {
+              return (
+                <Tooltip label='コピーされました' closeDelay={1500} withArrow>
+                  <ActionIcon color='teal' variant='subtle' onClick={copy}>
+                    <IconCheck style={{ width: rem(16) }} />
+                  </ActionIcon>
+                </Tooltip>
+              )
+            }
+            return (
+              <ActionIcon color='gray' variant='subtle' onClick={copy}>
+                <IconCopy style={{ width: rem(16) }} />
               </ActionIcon>
-            </Tooltip>
-          )}
+            )
+          }}
         </CopyButton>
       </Box>
 

--- a/src/client/component/markdown/RichCode.tsx
+++ b/src/client/component/markdown/RichCode.tsx
@@ -51,8 +51,12 @@ export function RichCode({ code, lang }: CodeBlockProps) {
               )
             }
             return (
-              <ActionIcon color='gray' variant='subtle' onClick={copy}>
-                <IconCopy style={{ width: rem(16) }} />
+              <ActionIcon
+                color='var(--code-bg, var(--mantine-color-gray-1))'
+                variant='filled'
+                onClick={copy}
+              >
+                <IconCopy color='gray' style={{ width: rem(16) }} />
               </ActionIcon>
             )
           }}
@@ -70,8 +74,6 @@ export function RichCode({ code, lang }: CodeBlockProps) {
     </Stack>
   )
 }
-
-function OverlayCopyButton({ value }: { value: string }) {}
 
 function isLangSupported(lang: string): lang is keyof typeof bundledLanguages {
   return supportedLanguageNames.includes(lang)

--- a/src/client/component/markdown/RichCode.tsx
+++ b/src/client/component/markdown/RichCode.tsx
@@ -1,4 +1,13 @@
-import { Code } from '@mantine/core'
+import {
+  ActionIcon,
+  Box,
+  Code,
+  CopyButton,
+  Stack,
+  Tooltip,
+  rem,
+} from '@mantine/core'
+import { IconCheck, IconCopy } from '@tabler/icons-react'
 import { bundledLanguages, bundledThemes, createHighlighter } from 'shiki'
 
 type CodeBlockProps = {
@@ -21,10 +30,47 @@ export function RichCode({ code, lang }: CodeBlockProps) {
   })
 
   return (
-    // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-    <Code block dangerouslySetInnerHTML={{ __html: html }} />
+    <Stack pos='relative'>
+      <Box
+        pos='absolute'
+        top='0'
+        right='0'
+        mt='5px'
+        mr='6px'
+        style={{ zIndex: 5 }}
+      >
+        <CopyButton value={code} timeout={1500}>
+          {({ copied, copy }) => (
+            <Tooltip label={copied ? 'コピーされました' : 'コピー'} withArrow>
+              <ActionIcon
+                color={copied ? 'teal' : 'gray'}
+                variant='subtle'
+                onClick={copy}
+              >
+                {copied ? (
+                  <IconCheck style={{ width: rem(16) }} />
+                ) : (
+                  <IconCopy style={{ width: rem(16) }} />
+                )}
+              </ActionIcon>
+            </Tooltip>
+          )}
+        </CopyButton>
+      </Box>
+
+      <Code
+        block
+        // codeが空文字列の場合でも、一行分は表示されるようにする
+        // min-height = line-height * font-size + 上下のpaddingの合計
+        mih='calc(var(--mantine-line-height) * var(--mantine-font-size-xs) + var(--mantine-spacing-xs) * 2)'
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </Stack>
   )
 }
+
+function OverlayCopyButton({ value }: { value: string }) {}
 
 function isLangSupported(lang: string): lang is keyof typeof bundledLanguages {
   return supportedLanguageNames.includes(lang)

--- a/src/client/component/markdown/RichCode.tsx
+++ b/src/client/component/markdown/RichCode.tsx
@@ -6,6 +6,7 @@ import {
   Stack,
   Tooltip,
   rem,
+  useMantineTheme,
 } from '@mantine/core'
 import { IconCheck, IconCopy } from '@tabler/icons-react'
 import { useEffect, useState } from 'react'
@@ -41,23 +42,34 @@ export function RichCode({ code, lang }: CodeBlockProps) {
       >
         <CopyButton value={code} timeout={1500}>
           {({ copied, copy }) => {
+            const theme = useMantineTheme()
+
             if (copied) {
               return (
                 <Tooltip label='コピーされました' closeDelay={1500} withArrow>
-                  <ActionIcon color='teal' variant='subtle' onClick={copy}>
-                    <IconCheck style={{ width: rem(16) }} />
+                  <ActionIcon
+                    color='var(--code-bg, var(--mantine-color-gray-1))'
+                    variant='filled'
+                    onClick={copy}
+                  >
+                    <IconCheck
+                      color={theme.colors.teal[6]}
+                      style={{ width: rem(16) }}
+                    />
                   </ActionIcon>
                 </Tooltip>
               )
             }
             return (
-              <ActionIcon
-                color='var(--code-bg, var(--mantine-color-gray-1))'
-                variant='filled'
-                onClick={copy}
-              >
-                <IconCopy color='gray' style={{ width: rem(16) }} />
-              </ActionIcon>
+              <>
+                <ActionIcon
+                  color='var(--code-bg, var(--mantine-color-gray-1))'
+                  variant='filled'
+                  onClick={copy}
+                >
+                  <IconCopy color='gray' style={{ width: rem(16) }} />
+                </ActionIcon>
+              </>
             )
           }}
         </CopyButton>


### PR DESCRIPTION
## 変更点
- コードブロックの右上にコピーボタンを追加
  - ホバー時にTooltipを表示
    - 通常: 「コピー」
    - コピー後1.5秒間: 「コピーされました」
  - コピー後はチェックマークを表示
- コードブロックの中身が空文字列の場合でも、１行分のコードブロックを表示するように修正

## スクショ
![スクリーンショット 2024-11-15 16 12 35](https://github.com/user-attachments/assets/2593a498-bfd1-4ae5-aa8b-ccbd24903808)
