### PR TITLE
シンプルな login API を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 .idea/workspace.xml
 .idea/usage.statistics.xml
 .idea/shelf
+.idea/dataSources.xml
 
 # deps
 node_modules/

--- a/drizzle/0006_wet_storm.sql
+++ b/drizzle/0006_wet_storm.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `users` (
+	`id` text PRIMARY KEY NOT NULL,
+	`password` text NOT NULL
+);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,119 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c903d28e-17ef-4743-8c62-48d580bf81e5",
+  "prevId": "72a7b97b-7362-4559-b134-135d41ca7b9c",
+  "tables": {
+    "fragments": {
+      "name": "fragments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scrap_id": {
+          "name": "scrap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fragments_scrap_id_scraps_id_fk": {
+          "name": "fragments_scrap_id_scraps_id_fk",
+          "tableFrom": "fragments",
+          "tableTo": "scraps",
+          "columnsFrom": [
+            "scrap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraps": {
+      "name": "scraps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1731718642152,
       "tag": "0005_old_selene",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1733150671338,
+      "tag": "0006_wet_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@tabler/icons-react": "^3.21.0",
     "@tanstack/react-router": "^1.77.5",
+    "argon2": "^0.41.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",

--- a/src/common/model/session.ts
+++ b/src/common/model/session.ts
@@ -1,0 +1,11 @@
+import type { Brand } from '@/common/brand'
+import type { UserId } from '@/common/model/user'
+import { z } from 'zod'
+
+export type SessionId = Brand<string, 'SessionId'>
+
+export const SessionSchema = z.object({
+  id: z.string().transform((v) => v as SessionId),
+  userId: z.string().transform((v) => v as UserId),
+})
+export type Session = z.infer<typeof SessionSchema>

--- a/src/common/model/session.ts
+++ b/src/common/model/session.ts
@@ -1,5 +1,6 @@
 import type { Brand } from '@/common/brand'
 import type { UserId } from '@/common/model/user'
+import { ulid } from 'ulidx'
 import { z } from 'zod'
 
 export type SessionId = Brand<string, 'SessionId'>
@@ -9,3 +10,14 @@ export const SessionSchema = z.object({
   userId: z.string().transform((v) => v as UserId),
 })
 export type Session = z.infer<typeof SessionSchema>
+
+export function createSession(userId: UserId): Session {
+  return {
+    id: generateSessionId(),
+    userId,
+  }
+}
+
+function generateSessionId(): SessionId {
+  return ulid() as SessionId
+}

--- a/src/common/model/session.ts
+++ b/src/common/model/session.ts
@@ -1,6 +1,5 @@
 import type { Brand } from '@/common/brand'
 import type { UserId } from '@/common/model/user'
-import { ulid } from 'ulidx'
 import { z } from 'zod'
 
 export type SessionId = Brand<string, 'SessionId'>
@@ -10,14 +9,3 @@ export const SessionSchema = z.object({
   userId: z.string().transform((v) => v as UserId),
 })
 export type Session = z.infer<typeof SessionSchema>
-
-export function createSession(userId: UserId): Session {
-  return {
-    id: generateSessionId(),
-    userId,
-  }
-}
-
-function generateSessionId(): SessionId {
-  return ulid() as SessionId
-}

--- a/src/common/model/user.ts
+++ b/src/common/model/user.ts
@@ -1,0 +1,7 @@
+import type { Brand } from '@/common/brand'
+
+export type UserId = Brand<string, 'UserId'>
+
+export interface User {
+  id: UserId
+}

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,13 +1,15 @@
+import { sessionRepositoryMiddleware } from '@/server/middleware/sessionRepository'
 import scrapFragments from '@/server/routes/scrapFragments'
 import { Hono } from 'hono'
 import type { AppEnv } from './env'
 import { drizzleMiddleware } from './middleware/drizzle'
+import auth from './routes/auth'
 import fragments from './routes/fragments'
 import scraps from './routes/scraps'
 
 const api = new Hono<AppEnv>()
 
-api.use(drizzleMiddleware)
+api.use(drizzleMiddleware).use(sessionRepositoryMiddleware)
 
 /**
  * scraps などは /scraps などの basePath が指定されているので、/ に連結する

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -27,6 +27,7 @@ const routes = api
   .route('/', scraps)
   .route('/', fragments)
   .route('/', scrapFragments)
+  .route('/', auth)
 
 export type ApiType = typeof routes
 export default api

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -26,3 +26,8 @@ export const scraps = sqliteTable('scraps', {
 export const scrapsRelations = relations(scraps, ({ many }) => ({
   fragments: many(fragments),
 }))
+
+export const users = sqliteTable('users', {
+  id: text().primaryKey(),
+  password: text().notNull(),
+})

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,4 +1,5 @@
 import type { FragmentId } from '@/common/model/fragment'
+import type { UserId } from '@/common/model/user'
 import { relations, sql } from 'drizzle-orm'
 import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
@@ -28,6 +29,6 @@ export const scrapsRelations = relations(scraps, ({ many }) => ({
 }))
 
 export const users = sqliteTable('users', {
-  id: text().primaryKey(),
+  id: text().$type<UserId>().primaryKey(),
   password: text().notNull(),
 })

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -2,7 +2,10 @@ import type * as schema from '@/server/db/schema'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 
 export type AppEnv = {
-  Bindings: { DB: D1Database }
+  Bindings: {
+    DB: D1Database
+    SESSION_KV: KVNamespace
+  }
   Variables: {
     db: DrizzleD1Database<typeof schema> & { $client: D1Database }
   }

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -1,4 +1,5 @@
 import type * as schema from '@/server/db/schema'
+import type { ISessionRepository } from '@/server/repository/session'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 
 export type AppEnv = {
@@ -8,5 +9,6 @@ export type AppEnv = {
   }
   Variables: {
     db: DrizzleD1Database<typeof schema> & { $client: D1Database }
+    sessionRepository: ISessionRepository
   }
 }

--- a/src/server/middleware/sessionRepository.ts
+++ b/src/server/middleware/sessionRepository.ts
@@ -1,0 +1,11 @@
+import { KVSessionRepository } from '@/server/repository/session'
+import { createMiddleware } from 'hono/factory'
+import type { AppEnv } from '../env'
+
+export const sessionRepositoryMiddleware = createMiddleware<AppEnv>(
+  async (c, next) => {
+    const sessionRepository = new KVSessionRepository(c.env.SESSION_KV)
+    c.set('sessionRepository', sessionRepository)
+    await next()
+  },
+)

--- a/src/server/repository/session.ts
+++ b/src/server/repository/session.ts
@@ -3,16 +3,29 @@ import {
   type SessionId,
   SessionSchema,
 } from '@/common/model/session'
+import type { UserId } from '@/common/model/user'
+import { ulid } from 'ulidx'
 
 export interface ISessionRepository {
-  storeSession(session: Session): Promise<void>
+  createSession(userId: UserId): Promise<Session>
   loadSession(sessionId: SessionId): Promise<Session | null>
 }
 
 export class KVSessionRepository implements ISessionRepository {
   constructor(private kv: KVNamespace) {}
 
-  async storeSession(session: Session): Promise<void> {
+  async createSession(userId: UserId): Promise<Session> {
+    const sessionId = this.generateSessionId()
+    const session: Session = {
+      id: sessionId,
+      userId,
+    }
+    await this.storeSession(session)
+
+    return session
+  }
+
+  private async storeSession(session: Session): Promise<void> {
     const key = this.formatKey(session.id)
     await this.kv.put(key, JSON.stringify(session))
   }
@@ -34,5 +47,9 @@ export class KVSessionRepository implements ISessionRepository {
 
   private formatKey(sessionId: SessionId): string {
     return `session:${sessionId}`
+  }
+
+  private generateSessionId(): SessionId {
+    return ulid() as SessionId
   }
 }

--- a/src/server/repository/session.ts
+++ b/src/server/repository/session.ts
@@ -11,7 +11,7 @@ const SessionSchema = z.object({
 })
 export type Session = z.infer<typeof SessionSchema>
 
-interface ISessionRepository {
+export interface ISessionRepository {
   createSession(userId: UserId): Promise<Session>
   storeSession(session: Session): Promise<void>
   loadSession(sessionId: SessionId): Promise<Session | null>

--- a/src/server/repository/session.ts
+++ b/src/server/repository/session.ts
@@ -1,15 +1,10 @@
-import type { Brand } from '@/common/brand'
+import {
+  type Session,
+  type SessionId,
+  SessionSchema,
+} from '@/common/model/session'
 import type { UserId } from '@/common/model/user'
 import { ulid } from 'ulidx'
-import { z } from 'zod'
-
-export type SessionId = Brand<string, 'SessionId'>
-
-const SessionSchema = z.object({
-  id: z.string().transform((v) => v as SessionId),
-  userId: z.string().transform((v) => v as UserId),
-})
-export type Session = z.infer<typeof SessionSchema>
 
 export interface ISessionRepository {
   createSession(userId: UserId): Promise<Session>

--- a/src/server/repository/session.ts
+++ b/src/server/repository/session.ts
@@ -1,0 +1,61 @@
+import type { Brand } from '@/common/brand'
+import type { UserId } from '@/common/model/user'
+import { ulid } from 'ulidx'
+import { z } from 'zod'
+
+export type SessionId = Brand<string, 'SessionId'>
+
+const SessionSchema = z.object({
+  id: z.string().transform((v) => v as SessionId),
+  userId: z.string().transform((v) => v as UserId),
+})
+export type Session = z.infer<typeof SessionSchema>
+
+interface ISessionRepository {
+  createSession(userId: UserId): Promise<Session>
+  storeSession(session: Session): Promise<void>
+  loadSession(sessionId: SessionId): Promise<Session | null>
+}
+
+export class KVSessionRepository implements ISessionRepository {
+  constructor(private kv: KVNamespace) {}
+
+  async createSession(userId: UserId): Promise<Session> {
+    const sessionId = this.generateSessionId()
+    const session: Session = {
+      id: sessionId,
+      userId,
+    }
+    await this.storeSession(session)
+
+    return session
+  }
+
+  async storeSession(session: Session): Promise<void> {
+    const key = this.formatKey(session.id)
+    await this.kv.put(key, JSON.stringify(session))
+  }
+
+  async loadSession(sessionId: SessionId): Promise<Session | null> {
+    const key = this.formatKey(sessionId)
+    const rawSessionString = await this.kv.get(key)
+    if (!rawSessionString) {
+      return null
+    }
+
+    try {
+      return SessionSchema.parse(JSON.parse(rawSessionString))
+    } catch (e) {
+      console.error(e)
+      return null
+    }
+  }
+
+  private generateSessionId(): SessionId {
+    return ulid() as SessionId
+  }
+
+  private formatKey(sessionId: SessionId): string {
+    return `session:${sessionId}`
+  }
+}

--- a/src/server/repository/session.ts
+++ b/src/server/repository/session.ts
@@ -3,28 +3,14 @@ import {
   type SessionId,
   SessionSchema,
 } from '@/common/model/session'
-import type { UserId } from '@/common/model/user'
-import { ulid } from 'ulidx'
 
 export interface ISessionRepository {
-  createSession(userId: UserId): Promise<Session>
   storeSession(session: Session): Promise<void>
   loadSession(sessionId: SessionId): Promise<Session | null>
 }
 
 export class KVSessionRepository implements ISessionRepository {
   constructor(private kv: KVNamespace) {}
-
-  async createSession(userId: UserId): Promise<Session> {
-    const sessionId = this.generateSessionId()
-    const session: Session = {
-      id: sessionId,
-      userId,
-    }
-    await this.storeSession(session)
-
-    return session
-  }
 
   async storeSession(session: Session): Promise<void> {
     const key = this.formatKey(session.id)
@@ -44,10 +30,6 @@ export class KVSessionRepository implements ISessionRepository {
       console.error(e)
       return null
     }
-  }
-
-  private generateSessionId(): SessionId {
-    return ulid() as SessionId
   }
 
   private formatKey(sessionId: SessionId): string {

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,0 +1,37 @@
+import type { UserId } from '@/common/model/user'
+import type { AppEnv } from '@/server/env'
+import { zValidator } from '@hono/zod-validator'
+import argon2 from 'argon2'
+import { Hono } from 'hono'
+import { z } from 'zod'
+
+const auth = new Hono<AppEnv>().basePath('/auth').post(
+  '/login',
+  zValidator(
+    'json',
+    z.object({
+      userId: z.string().transform((v) => v as UserId),
+      password: z.string(),
+    }),
+  ),
+  async (c) => {
+    const { userId, password } = c.req.valid('json')
+    const user = await c.var.db.query.users.findFirst({
+      where: (users, { eq }) => eq(users.id, userId),
+    })
+    if (!user) {
+      return c.body(null, 401)
+    }
+
+    const isValid = await argon2.verify(user.password, password)
+    if (!isValid) {
+      return c.body(null, 401)
+    }
+
+    const session = await c.var.sessionRepository.createSession(userId)
+
+    return c.json(session)
+  },
+)
+
+export default auth

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,20 +1,22 @@
 import type { UserId } from '@/common/model/user'
+import * as schema from '@/server/db/schema'
 import type { AppEnv } from '@/server/env'
 import { zValidator } from '@hono/zod-validator'
 import argon2 from 'argon2'
 import { Hono } from 'hono'
 import { z } from 'zod'
 
-const auth = new Hono<AppEnv>().basePath('/auth').post(
-  '/login',
-  zValidator(
-    'json',
-    z.object({
-      userId: z.string().transform((v) => v as UserId),
-      password: z.string(),
-    }),
-  ),
-  async (c) => {
+const authInputValidator = zValidator(
+  'json',
+  z.object({
+    userId: z.string().transform((v) => v as UserId),
+    password: z.string(),
+  }),
+)
+
+const auth = new Hono<AppEnv>()
+  .basePath('/auth')
+  .post('/login', authInputValidator, async (c) => {
     const { userId, password } = c.req.valid('json')
     const user = await c.var.db.query.users.findFirst({
       where: (users, { eq }) => eq(users.id, userId),
@@ -31,7 +33,16 @@ const auth = new Hono<AppEnv>().basePath('/auth').post(
     const session = await c.var.sessionRepository.createSession(userId)
 
     return c.json(session)
-  },
-)
+  })
+  .post('/register', authInputValidator, async (c) => {
+    // TODO: これは動作確認用の仮実装
+    const { userId, password } = c.req.valid('json')
+    const hash = await argon2.hash(password)
+    await c.var.db.insert(schema.users).values({
+      id: userId,
+      password: hash,
+    })
+    return c.body(null, 201)
+  })
 
 export default auth

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,3 +1,4 @@
+import { createSession } from '@/common/model/session'
 import type { UserId } from '@/common/model/user'
 import * as schema from '@/server/db/schema'
 import type { AppEnv } from '@/server/env'
@@ -35,7 +36,8 @@ const auth = new Hono<AppEnv>()
       return c.body(null, 401)
     }
 
-    const session = await c.var.sessionRepository.createSession(userId)
+    const session = createSession(userId)
+    await c.var.sessionRepository.storeSession(session)
 
     return c.json(session)
   })

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,4 +1,3 @@
-import { createSession } from '@/common/model/session'
 import type { UserId } from '@/common/model/user'
 import * as schema from '@/server/db/schema'
 import type { AppEnv } from '@/server/env'
@@ -36,8 +35,7 @@ const auth = new Hono<AppEnv>()
       return c.body(null, 401)
     }
 
-    const session = createSession(userId)
-    await c.var.sessionRepository.storeSession(session)
+    const session = await c.var.sessionRepository.createSession(userId)
 
     return c.json(session)
   })

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,22 +3,12 @@ compatibility_date = "2024-10-21"
 pages_build_output_dir = "./dist"
 compatibility_flags = [ "nodejs_compat" ]
 
-# [vars]
-# MY_VAR = "my-variable"
-
-# [[kv_namespaces]]
-# binding = "MY_KV_NAMESPACE"
-# id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
-# [[r2_buckets]]
-# binding = "MY_BUCKET"
-# bucket_name = "my-bucket"
+[[kv_namespaces]]
+binding = "SESSION_KV"
+id = "c05d577e52254456931cef1e83fb0cf4"
 
 [[d1_databases]]
 binding = "DB" # i.e. available in your Worker on env.DB
 database_name = "scrap"
 database_id = "5c11a0e5-3460-480c-bb5c-0971dd645f47"
 migrations_dir = "drizzle"
-
-# [ai]
-# binding = "AI"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,6 +9,6 @@ id = "c05d577e52254456931cef1e83fb0cf4"
 
 [[d1_databases]]
 binding = "DB" # i.e. available in your Worker on env.DB
-database_name = "scrap_prod"
+database_name = "scrap"
 database_id = "5c11a0e5-3460-480c-bb5c-0971dd645f47"
 migrations_dir = "drizzle"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,6 +1065,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@phc/format@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@phc/format/-/format-1.0.0.tgz#b5627003b3216dc4362125b13f48a4daa76680e4"
+  integrity sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==
+
 "@radix-ui/react-compose-refs@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz#656432461fc8283d7b591dcf0d79152fae9ecc74"
@@ -1459,6 +1464,15 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+argon2@^0.41.1:
+  version "0.41.1"
+  resolved "https://registry.yarnpkg.com/argon2/-/argon2-0.41.1.tgz#30ce6b013e273bc7e92c558d40e66d35e5e8c63b"
+  integrity sha512-dqCW8kJXke8Ik+McUcMDltrbuAWETPyU6iq+4AhxqKphWi7pChB/Zgd/Tp/o8xRLbg8ksMj46F/vph9wnxpTzQ==
+  dependencies:
+    "@phc/format" "^1.0.0"
+    node-addon-api "^8.1.0"
+    node-gyp-build "^4.8.1"
 
 as-table@^1.0.36:
   version "1.0.55"
@@ -2687,10 +2701,20 @@ nanoid@^3.3.3, nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
+node-addon-api@^8.1.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.3.0.tgz#ec3763f18befc1cdf66d11e157ce44d5eddc0603"
+  integrity sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==
+
 node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
+node-gyp-build@^4.8.1:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
+  integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 node-releases@^2.0.18:
   version "2.0.18"


### PR DESCRIPTION
user 関連を全部実装すると差分がデカそうだったので、シンプルな login API だけ実装しました。
例外処理とかめっちゃ適当です。

argon2 が cloudflare で動くのかちゃんと検証してないです。wrangler のコンパイルは通ったし、`nodejs_compat` なら動くんじゃないかと思ってます。

## 動作確認手順
ユーザーを作成する (`/api/auth/register` は login のデバッグ用に仮実装しました)
```shell
curl -X POST http://localhost:5173/api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"userId":"kemizuki","password":"password"}'
```

login する
```shell
curl -X POST http://localhost:5173/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"userId":"kemizuki","password":"password"}'
```
うまく行けば session id が発行されます。
```json
{
  "id": "01JE45C86NDZED1TRS1XW324DA",
  "userId": "kemizuki"
}
```

KV にセッションが保存されていることを確認する。`$SESSION_ID` は上で返されたものに置き換えてください。
```shell
wrangler kv key get "session:$SESSION_ID" --binding SESSION_KV --local
```