### PR TITLE
Session ID を Cookie で受け渡すように & 認証 Middleware を実装

### DIFF
--- a/src/server/constant/session.ts
+++ b/src/server/constant/session.ts
@@ -1,0 +1,1 @@
+export const SESSION_COOKIE_NAME = 'session'

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -1,3 +1,4 @@
+import type { Session } from '@/common/model/session'
 import type * as schema from '@/server/db/schema'
 import type { ISessionRepository } from '@/server/repository/session'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
@@ -10,5 +11,6 @@ export type AppEnv = {
   Variables: {
     db: DrizzleD1Database<typeof schema> & { $client: D1Database }
     sessionRepository: ISessionRepository
+    session: Session | null
   }
 }

--- a/src/server/middleware/sessionAuth.ts
+++ b/src/server/middleware/sessionAuth.ts
@@ -1,0 +1,24 @@
+import type { SessionId } from '@/common/model/session'
+import { getCookie } from 'hono/cookie'
+import { createMiddleware } from 'hono/factory'
+import { SESSION_COOKIE_NAME } from '../constant/session'
+import type { AppEnv } from '../env'
+
+export const sessionAuthMiddleware = createMiddleware<AppEnv>(
+  async (c, next) => {
+    const sessionCookieValue = getCookie(c, SESSION_COOKIE_NAME)
+    if (!sessionCookieValue) {
+      return c.body(null, 401)
+    }
+
+    const sessionId = sessionCookieValue as SessionId
+    const session = await c.var.sessionRepository.loadSession(sessionId)
+    if (!session) {
+      return c.body(null, 401)
+    }
+
+    c.set('session', session)
+
+    return await next()
+  },
+)

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -6,7 +6,7 @@ import { sessionAuthMiddleware } from '@/server/middleware/sessionAuth'
 import { zValidator } from '@hono/zod-validator'
 import argon2 from 'argon2'
 import { Hono } from 'hono'
-import { setCookie } from 'hono/cookie'
+import { deleteCookie, setCookie } from 'hono/cookie'
 import { z } from 'zod'
 
 const authInputValidator = zValidator(
@@ -76,6 +76,7 @@ const auth = new Hono<AppEnv>()
     }
 
     await c.var.sessionRepository.removeSession(session)
+    deleteCookie(c, SESSION_COOKIE_NAME)
 
     return c.body(null, 204)
   })


### PR DESCRIPTION
JetBrains の HTTP Client を使う場合の動作確認

```
### ユーザー登録
POST http://localhost:5173/api/auth/register
Content-Type: application/json

{ "userId": "kemizuki", "password": "password" }

### Session ID が set-cookie される
POST http://localhost:5173/api/auth/login
Content-Type: application/json

{ "userId": "kemizuki", "password": "password" }

### HTTP Client が勝手に Cookie を送ってくれる。Cookie がなければ 401 が返る。
### set-cookie で session cookie が消される
POST http://localhost:5173/api/auth/logout
Content-Type: application/json
```