### PR TITLE
users とその他のテーブル間の relation

### DIFF
--- a/drizzle/0007_flat_wong.sql
+++ b/drizzle/0007_flat_wong.sql
@@ -1,0 +1,14 @@
+PRAGMA foreign_keys = OFF;
+PRAGMA defer_foreign_keys = ON;
+-- owner_id なしの scraps からデータを引き継げないので、削除する
+DROP TABLE `scraps`;
+CREATE TABLE `scraps`
+(
+    `id`         text PRIMARY KEY                 NOT NULL,
+    `title`      text                             NOT NULL,
+    `updated_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    `owner_id`   text                             NOT NULL,
+    FOREIGN KEY (`owner_id`) REFERENCES `users` (`id`) ON UPDATE no action ON DELETE cascade
+);
+PRAGMA foreign_keys = ON;
+PRAGMA defer_foreign_keys = OFF;

--- a/drizzle/0008_lean_spencer_smythe.sql
+++ b/drizzle/0008_lean_spencer_smythe.sql
@@ -1,0 +1,15 @@
+PRAGMA foreign_keys = OFF;
+PRAGMA defer_foreign_keys = ON;
+-- author_id なしのデータを引き継げないので、削除する
+DROP TABLE `fragments`;
+CREATE TABLE `fragments`
+(
+    `id`        integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    `content`   text                              NOT NULL,
+    `scrap_id`  text                              NOT NULL,
+    `author_id` text                              NOT NULL,
+    FOREIGN KEY (`scrap_id`) REFERENCES `scraps` (`id`) ON UPDATE no action ON DELETE no action,
+    FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON UPDATE no action ON DELETE cascade
+);
+PRAGMA foreign_keys = ON;
+PRAGMA defer_foreign_keys = OFF;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,140 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e126c9a1-d931-4323-b7be-bbefe7422339",
+  "prevId": "c903d28e-17ef-4743-8c62-48d580bf81e5",
+  "tables": {
+    "fragments": {
+      "name": "fragments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scrap_id": {
+          "name": "scrap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fragments_scrap_id_scraps_id_fk": {
+          "name": "fragments_scrap_id_scraps_id_fk",
+          "tableFrom": "fragments",
+          "tableTo": "scraps",
+          "columnsFrom": [
+            "scrap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraps": {
+      "name": "scraps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scraps_owner_id_users_id_fk": {
+          "name": "scraps_owner_id_users_id_fk",
+          "tableFrom": "scraps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,160 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cee9c076-dfea-427d-b7d3-be89264ade6a",
+  "prevId": "e126c9a1-d931-4323-b7be-bbefe7422339",
+  "tables": {
+    "fragments": {
+      "name": "fragments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scrap_id": {
+          "name": "scrap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fragments_scrap_id_scraps_id_fk": {
+          "name": "fragments_scrap_id_scraps_id_fk",
+          "tableFrom": "fragments",
+          "tableTo": "scraps",
+          "columnsFrom": [
+            "scrap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fragments_author_id_users_id_fk": {
+          "name": "fragments_author_id_users_id_fk",
+          "tableFrom": "fragments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraps": {
+      "name": "scraps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scraps_owner_id_users_id_fk": {
+          "name": "scraps_owner_id_users_id_fk",
+          "tableFrom": "scraps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1733150671338,
       "tag": "0006_wet_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1733407421825,
+      "tag": "0007_flat_wong",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1733407421825,
       "tag": "0007_flat_wong",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1733418611394,
+      "tag": "0008_lean_spencer_smythe",
+      "breakpoints": true
     }
   ]
 }

--- a/src/common/model/fragment.ts
+++ b/src/common/model/fragment.ts
@@ -10,4 +10,4 @@ export interface Fragment {
   content: string
 }
 
-export type FragmentInput = Omit<Fragment, 'id'>
+export type FragmentInput = Omit<Fragment, 'id' | 'scrapId' | 'authorId'>

--- a/src/common/model/fragment.ts
+++ b/src/common/model/fragment.ts
@@ -1,9 +1,12 @@
 import type { Brand } from '@/common/brand'
+import type { UserId } from '@/common/model/user'
 
 export type FragmentId = Brand<number, 'FragmentId'>
 
 export interface Fragment {
   id: FragmentId
+  scrapId: string
+  authorId: UserId
   content: string
 }
 

--- a/src/common/model/scrap.ts
+++ b/src/common/model/scrap.ts
@@ -1,8 +1,10 @@
 import type { Fragment } from '@/common/model/fragment'
+import type { UserId } from '@/common/model/user'
 
 export interface Scrap {
   id: string
   title: string
   fragments: Fragment[]
   updatedAt: string
+  ownerId: UserId
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -9,11 +9,19 @@ export const fragments = sqliteTable('fragments', {
   scrapId: text('scrap_id')
     .notNull()
     .references(() => scraps.id),
+  authorId: text('author_id')
+    .$type<UserId>()
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
 })
 export const fragmentsRelations = relations(fragments, ({ one }) => ({
   scrap: one(scraps, {
     fields: [fragments.scrapId],
     references: [scraps.id],
+  }),
+  author: one(users, {
+    fields: [fragments.authorId],
+    references: [users.id],
   }),
 }))
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -10,7 +10,6 @@ export const fragments = sqliteTable('fragments', {
     .notNull()
     .references(() => scraps.id),
 })
-
 export const fragmentsRelations = relations(fragments, ({ one }) => ({
   scrap: one(scraps, {
     fields: [fragments.scrapId],
@@ -22,13 +21,25 @@ export const scraps = sqliteTable('scraps', {
   id: text().primaryKey(),
   title: text().notNull(),
   updatedAt: text('updated_at').default(sql`(CURRENT_TIMESTAMP)`).notNull(),
+  ownerId: text('owner_id')
+    .$type<UserId>()
+    .notNull()
+    .references(() => users.id, {
+      onDelete: 'cascade',
+    }),
 })
-
-export const scrapsRelations = relations(scraps, ({ many }) => ({
+export const scrapsRelations = relations(scraps, ({ one, many }) => ({
   fragments: many(fragments),
+  owner: one(users, {
+    fields: [scraps.ownerId],
+    references: [users.id],
+  }),
 }))
 
 export const users = sqliteTable('users', {
   id: text().$type<UserId>().primaryKey(),
   password: text().notNull(),
 })
+export const usersRelations = relations(users, ({ many }) => ({
+  scraps: many(scraps),
+}))


### PR DESCRIPTION
以下のリレーションを設定した
- `user` has many `scraps` / `scraps` has one `owner` (`user`)
- `fragment` has one `author` (`user`)
  - 逆は使わなそうだったので relation を設定していない。migration 不要なのでもし必要になったら足せばいい。

また、例えば scrap の owner を設定するのにログインユーザーの情報が必要なので、API をログイン必須にした
