### PR TITLE
セッションの有効期限を設定する

### DIFF
--- a/src/server/constant/session.ts
+++ b/src/server/constant/session.ts
@@ -1,1 +1,2 @@
 export const SESSION_COOKIE_NAME = 'session'
+export const SESSION_TTL = 60 * 60 * 24 * 14 // 2 weeks

--- a/src/server/middleware/sessionAuth.ts
+++ b/src/server/middleware/sessionAuth.ts
@@ -1,6 +1,7 @@
 import type { SessionId } from '@/common/model/session'
-import { getCookie } from 'hono/cookie'
+import { deleteCookie, getCookie } from 'hono/cookie'
 import { createMiddleware } from 'hono/factory'
+import { HTTPException } from 'hono/http-exception'
 import { SESSION_COOKIE_NAME } from '../constant/session'
 import type { AppEnv } from '../env'
 
@@ -8,12 +9,15 @@ export const sessionAuthMiddleware = createMiddleware<AppEnv>(
   async (c, next) => {
     const sessionCookieValue = getCookie(c, SESSION_COOKIE_NAME)
     if (!sessionCookieValue) {
-      return c.body(null, 401)
+      throw new HTTPException(401)
     }
 
     const sessionId = sessionCookieValue as SessionId
     const session = await c.var.sessionRepository.loadSession(sessionId)
     if (!session) {
+      // cookie を削除しないと 401 が返され続ける
+      deleteCookie(c, SESSION_COOKIE_NAME)
+      // 例外を投げると deleteCookie が反映されない
       return c.body(null, 401)
     }
 

--- a/src/server/middleware/sessionRepository.ts
+++ b/src/server/middleware/sessionRepository.ts
@@ -1,10 +1,14 @@
+import { SESSION_TTL } from '@/server/constant/session'
 import { KVSessionRepository } from '@/server/repository/session'
 import { createMiddleware } from 'hono/factory'
 import type { AppEnv } from '../env'
 
 export const sessionRepositoryMiddleware = createMiddleware<AppEnv>(
   async (c, next) => {
-    const sessionRepository = new KVSessionRepository(c.env.SESSION_KV)
+    const sessionRepository = new KVSessionRepository(
+      c.env.SESSION_KV,
+      SESSION_TTL,
+    )
     c.set('sessionRepository', sessionRepository)
     await next()
   },

--- a/src/server/repository/session.ts
+++ b/src/server/repository/session.ts
@@ -13,7 +13,10 @@ export interface ISessionRepository {
 }
 
 export class KVSessionRepository implements ISessionRepository {
-  constructor(private kv: KVNamespace) {}
+  constructor(
+    private kv: KVNamespace,
+    private ttl?: number,
+  ) {}
 
   async createSession(userId: UserId): Promise<Session> {
     const sessionId = this.generateSessionId()
@@ -28,7 +31,8 @@ export class KVSessionRepository implements ISessionRepository {
 
   private async storeSession(session: Session): Promise<void> {
     const key = this.formatKey(session.id)
-    await this.kv.put(key, JSON.stringify(session))
+    const options = this.ttl ? { expirationTtl: this.ttl } : undefined
+    await this.kv.put(key, JSON.stringify(session), options)
   }
 
   async loadSession(sessionId: SessionId): Promise<Session | null> {

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,5 +1,5 @@
 import type { User, UserId } from '@/common/model/user'
-import { SESSION_COOKIE_NAME } from '@/server/constant/session'
+import { SESSION_COOKIE_NAME, SESSION_TTL } from '@/server/constant/session'
 import * as schema from '@/server/db/schema'
 import type { AppEnv } from '@/server/env'
 import { sessionAuthMiddleware } from '@/server/middleware/sessionAuth'
@@ -44,6 +44,7 @@ const auth = new Hono<AppEnv>()
       sameSite: 'strict',
       // 開発環境で secure を有効化すると cookie が送られなくなるので、本番環境でのみ有効化する
       secure: import.meta.env.PROD,
+      maxAge: SESSION_TTL,
     })
 
     return c.body(null, 204)


### PR DESCRIPTION
KV, Cookie ともに 2 週間の TTL を設定した。
有効期限切れのセッションを参照する Cookie が渡されたとき、Cookie を削除するようにした。

動作確認方法:
1. ログインする
2. Cookie の `session` の値を確認
3. `wrangler kv key delete "session:$ID" --binding SESSION_KV --local` を実行して、サーバーセッションを無効化
4. ページをリロードするとログインページに飛ばされ、Cookie は削除される。